### PR TITLE
chore: remove tech stack section from project layout

### DIFF
--- a/layouts/projects/single.html
+++ b/layouts/projects/single.html
@@ -18,17 +18,6 @@
         {{ if eq .Params.endDate "2025-01-01" }}Present{{ else }}{{ dateFormat "Jan 2006" .Params.endDate }}{{ end }}
       </div>
     </div>
-    
-    {{ if .Params.techStack }}
-    <div class="project-tech-stack">
-      <h3>Technologies Used</h3>
-      <div class="tech-tags">
-        {{ range .Params.techStack }}
-        <span class="tech-tag">{{ . }}</span>
-        {{ end }}
-      </div>
-    </div>
-    {{ end }}
   </header>
 
   <div class="project-detail-content">


### PR DESCRIPTION
The "Technologies Used" section was removed from the project layout to simplify the display and reduce redundancy. This change aims to streamline the presentation of project details.