### PR TITLE
chore: temporarily disable theme toggle button in site navigation

### DIFF
--- a/layouts/partials/site-navigation.html
+++ b/layouts/partials/site-navigation.html
@@ -22,7 +22,7 @@
       {{ end }}
       
       <!-- Theme Toggle Button -->
-      <div class="theme-toggle-container {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
+      <!-- <div class="theme-toggle-container {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl3" "pr3" }}">
         <button 
           id="theme-toggle" 
           class="theme-toggle-btn"
@@ -32,7 +32,7 @@
           <span class="theme-icon" aria-hidden="true">🌙</span>
           <span class="theme-label sr-only">Auto</span>
         </button>
-      </div>
+      </div> -->
       
       {{ partialCached "social-follow.html" . }}
     </div>


### PR DESCRIPTION
The theme toggle button has been commented out in the site navigation partial. This change is likely made to temporarily disable the feature, possibly for testing purposes or due to a design decision.